### PR TITLE
Decouple API configuration from source

### DIFF
--- a/AppIntents/Models/TodoItem.swift
+++ b/AppIntents/Models/TodoItem.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct TodoItem: Codable, Hashable {
+    let taskName: String
+    let dueDate: Date?
+    let priority: String
+    let workload: String
+    let categories: [String]
+    let status: String
+    let notes: String
+    let isCompleted: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case taskName = "任务名称"
+        case dueDate = "截止日期"
+        case priority = "优先级"
+        case workload = "工作量等级"
+        case categories = "任务类型"
+        case status = "状态"
+        case notes = "描述"
+        case isCompleted = "复选框"
+    }
+}

--- a/AppIntents/ProcessScreenshotIntent.swift
+++ b/AppIntents/ProcessScreenshotIntent.swift
@@ -1,0 +1,115 @@
+import AppIntents
+import Foundation
+import Security
+import UniformTypeIdentifiers
+
+struct ProcessScreenshotIntent: AppIntent {
+    static var title: LocalizedStringResource = "OCR 截图并同步到 Notion"
+    static var description = IntentDescription("识别截图中的待办事项，调用 LLM 解析，并在 Notion 中创建任务。")
+
+    @Parameter(title: "截图文件", requestValueDialog: IntentDialog("请选择需要解析的截图"))
+    var screenshot: IntentFile
+
+    @Parameter(title: "当前日期")
+    var currentDate: Date
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("从 \(\.$screenshot) 创建任务，使用日期 \(\.$currentDate)")
+    }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[URL]> {
+        let imageData = try Data(contentsOf: screenshot.fileURL)
+
+        let ocrService = OCRService()
+        let text = try await ocrService.recognizeText(from: imageData)
+
+        let gptService = GPTService(configuration: .init(
+            apiKeyProvider: Secrets.gptAPIKey,
+            endpointProvider: Secrets.gptEndpoint,
+            modelProvider: Secrets.gptModel
+        ))
+        let todos = try await gptService.generateTodos(from: text, currentDate: currentDate)
+
+        let notionService = NotionService(configuration: .init(
+            tokenProvider: Secrets.notionToken,
+            dataSourceIdProvider: Secrets.notionDataSourceId,
+            endpointProvider: Secrets.notionPagesEndpoint,
+            apiVersionProvider: Secrets.notionAPIVersion
+        ))
+
+        let pages = try await notionService.createPages(from: todos)
+        let urls = pages.map { $0.url }
+
+        return .result(value: urls)
+    }
+}
+
+struct Secrets {
+    static func gptAPIKey() throws -> String {
+        try string(forKey: "gpt_api_key")
+    }
+
+    static func gptEndpoint() throws -> URL {
+        try url(forKey: "gpt_endpoint")
+    }
+
+    static func gptModel() throws -> String {
+        try string(forKey: "gpt_model")
+    }
+
+    static func notionToken() throws -> String {
+        try string(forKey: "notion_token")
+    }
+
+    static func notionDataSourceId() throws -> String {
+        try string(forKey: "notion_data_source_id")
+    }
+
+    static func notionPagesEndpoint() throws -> URL {
+        try url(forKey: "notion_pages_endpoint")
+    }
+
+    static func notionAPIVersion() throws -> String {
+        try string(forKey: "notion_api_version")
+    }
+
+    private static func string(forKey key: String) throws -> String {
+        guard let value = KeychainHelper.shared.token(forKey: key), value.isEmpty == false else {
+            throw SecretsError.missingKey
+        }
+        return value
+    }
+
+    private static func url(forKey key: String) throws -> URL {
+        let value = try string(forKey: key)
+        guard let url = URL(string: value) else {
+            throw SecretsError.invalidURL
+        }
+        return url
+    }
+}
+
+enum SecretsError: Error {
+    case missingKey
+    case invalidURL
+}
+
+final class KeychainHelper {
+    static let shared = KeychainHelper()
+
+    func token(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/AppIntents/Services/GPTService.swift
+++ b/AppIntents/Services/GPTService.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+enum GPTServiceError: Error {
+    case invalidResponse
+}
+
+struct GPTService {
+    struct Configuration {
+        let apiKeyProvider: () throws -> String
+        let endpointProvider: () throws -> URL
+        let modelProvider: () throws -> String
+    }
+
+    let configuration: Configuration
+    let urlSession: URLSession = .shared
+
+    struct RequestPayload: Encodable {
+        struct Message: Encodable {
+            let role: String
+            let content: String
+        }
+
+        let model: String
+        let messages: [Message]
+        let max_tokens: Int
+        let temperature: Double
+        let top_p: Double
+        let stream: Bool
+        let reasoning_effort: String
+    }
+
+    func generateTodos(from text: String, currentDate: Date) async throws -> [TodoItem] {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withFullDate]
+
+        let currentDateString = isoFormatter.string(from: currentDate)
+        let prompt = """
+        你是一个数据分析大师，你需要分析一下这个截图里面的待办事项，并输出 JSON。
+
+        当前日期：\(currentDateString)
+
+        要求：
+        1. 输出为一个 JSON 数组。
+        2. 字段包括：任务名称, 截止日期, 优先级, 工作量等级, 任务类型, 状态, 描述, 复选框。
+        3. 截止日期需要解析自然语言，例如“明天” → YYYY-MM-DD。
+        4. 输出必须是合法 JSON，不要包含额外解释。
+        文本内容：\n\(text)
+        """
+
+        let payload = RequestPayload(
+            model: try configuration.modelProvider(),
+            messages: [.init(role: "user", content: prompt)],
+            max_tokens: 1688,
+            temperature: 0.2,
+            top_p: 0.3,
+            stream: false,
+            reasoning_effort: "minimal"
+        )
+
+        var request = URLRequest(url: try configuration.endpointProvider())
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(try configuration.apiKeyProvider())", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+            throw GPTServiceError.invalidResponse
+        }
+
+        let content = try extractContent(from: data)
+        return try JSONDecoder.yyyyMMddDecoder.decode([TodoItem].self, from: Data(content.utf8))
+    }
+
+    private func extractContent(from data: Data) throws -> String {
+        struct APIResponse: Decodable {
+            struct Choice: Decodable {
+                struct Message: Decodable {
+                    let role: String
+                    let content: String
+                }
+                let message: Message
+            }
+            let choices: [Choice]
+        }
+
+        let response = try JSONDecoder().decode(APIResponse.self, from: data)
+        guard let content = response.choices.first?.message.content else {
+            throw GPTServiceError.invalidResponse
+        }
+        return content
+    }
+}

--- a/AppIntents/Services/JSONDecoder+yyyyMMdd.swift
+++ b/AppIntents/Services/JSONDecoder+yyyyMMdd.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension JSONDecoder {
+    static var yyyyMMddDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "zh_CN")
+        formatter.dateFormat = "yyyy-MM-dd"
+        decoder.dateDecodingStrategy = .formatted(formatter)
+        return decoder
+    }
+}

--- a/AppIntents/Services/NotionService.swift
+++ b/AppIntents/Services/NotionService.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+enum NotionServiceError: Error {
+    case invalidResponse
+}
+
+struct NotionService {
+    struct Configuration {
+        let tokenProvider: () throws -> String
+        let dataSourceIdProvider: () throws -> String
+        let endpointProvider: () throws -> URL
+        let apiVersionProvider: () throws -> String
+    }
+
+    struct PageResponse: Decodable {
+        let id: String
+        let url: URL
+    }
+
+    let configuration: Configuration
+    let urlSession: URLSession = .shared
+
+    func createPages(from todos: [TodoItem]) async throws -> [PageResponse] {
+        try await withThrowingTaskGroup(of: PageResponse.self) { group in
+            for todo in todos {
+                group.addTask {
+                    try await createPage(from: todo)
+                }
+            }
+
+            var results: [PageResponse] = []
+            for try await result in group {
+                results.append(result)
+            }
+            return results
+        }
+    }
+
+    private func createPage(from todo: TodoItem) async throws -> PageResponse {
+        var request = URLRequest(url: try configuration.endpointProvider())
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(try configuration.apiVersionProvider(), forHTTPHeaderField: "Notion-Version")
+        request.setValue("Bearer \(try configuration.tokenProvider())", forHTTPHeaderField: "Authorization")
+
+        let payload = try makePayload(from: todo)
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+            throw NotionServiceError.invalidResponse
+        }
+
+        return try JSONDecoder().decode(PageResponse.self, from: data)
+    }
+
+    private func makePayload(from todo: TodoItem) throws -> Payload {
+        Payload(
+            parent: .init(type: "data_source_id", data_source_id: try configuration.dataSourceIdProvider()),
+            properties: .init(todo: todo)
+        )
+    }
+}
+
+private struct Payload: Encodable {
+    struct Parent: Encodable {
+        let type: String
+        let data_source_id: String
+    }
+
+    struct Properties: Encodable {
+        struct TextBlock: Encodable {
+            struct TextContent: Encodable {
+                let content: String
+            }
+            let text: TextContent
+        }
+
+        struct MultiSelectOption: Encodable {
+            let name: String
+        }
+
+        struct StatusValue: Encodable {
+            let name: String
+        }
+
+        struct SelectValue: Encodable {
+            let name: String
+        }
+
+        struct DateValue: Encodable {
+            let start: String
+        }
+
+        let taskName: Title
+        let dueDate: DateProperty?
+        let priority: SelectProperty
+        let workload: SelectProperty
+        let categories: MultiSelectProperty
+        let status: StatusProperty
+        let notes: RichTextProperty
+        let checkbox: CheckboxProperty
+
+        enum CodingKeys: String, CodingKey {
+            case taskName = "任务名称"
+            case dueDate = "截止日期"
+            case priority = "优先级"
+            case workload = "工作量等级"
+            case categories = "任务类型"
+            case status = "状态"
+            case notes = "描述"
+            case checkbox = "复选框"
+        }
+
+        init(todo: TodoItem) {
+            self.taskName = Title(value: todo.taskName)
+            if let dueDate = todo.dueDate {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withFullDate]
+                self.dueDate = DateProperty(value: formatter.string(from: dueDate))
+            } else {
+                self.dueDate = nil
+            }
+            self.priority = SelectProperty(name: todo.priority)
+            self.workload = SelectProperty(name: todo.workload)
+            self.categories = MultiSelectProperty(names: todo.categories)
+            self.status = StatusProperty(name: todo.status)
+            self.notes = RichTextProperty(value: todo.notes)
+            self.checkbox = CheckboxProperty(value: todo.isCompleted)
+        }
+
+        struct Title: Encodable {
+            let title: [TextBlock]
+
+            init(value: String) {
+                self.title = [.init(text: .init(content: value))]
+            }
+        }
+
+        struct DateProperty: Encodable {
+            let date: DateValue
+
+            init(value: String) {
+                self.date = DateValue(start: value)
+            }
+        }
+
+        struct SelectProperty: Encodable {
+            let select: SelectValue
+
+            init(name: String) {
+                self.select = SelectValue(name: name)
+            }
+        }
+
+        struct MultiSelectProperty: Encodable {
+            let multi_select: [MultiSelectOption]
+
+            init(names: [String]) {
+                self.multi_select = names.map { MultiSelectOption(name: $0) }
+            }
+        }
+
+        struct StatusProperty: Encodable {
+            let status: StatusValue
+
+            init(name: String) {
+                self.status = StatusValue(name: name)
+            }
+        }
+
+        struct RichTextProperty: Encodable {
+            let rich_text: [TextBlock]
+
+            init(value: String) {
+                guard value.isEmpty == false else {
+                    self.rich_text = []
+                    return
+                }
+                self.rich_text = [.init(text: .init(content: value))]
+            }
+        }
+
+        struct CheckboxProperty: Encodable {
+            let checkbox: Bool
+
+            init(value: Bool) {
+                self.checkbox = value
+            }
+        }
+    }
+
+    let parent: Parent
+    let properties: Properties
+}

--- a/AppIntents/Services/OCRService.swift
+++ b/AppIntents/Services/OCRService.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Vision
+
+enum OCRServiceError: Error {
+    case imageConversionFailed
+    case recognitionFailed
+}
+
+struct OCRService {
+    func recognizeText(from imageData: Data) async throws -> String {
+        guard let image = CIImage(data: imageData) else {
+            throw OCRServiceError.imageConversionFailed
+        }
+
+        let handler = VNImageRequestHandler(ciImage: image, options: [:])
+        let request = VNRecognizeTextRequest()
+        request.recognitionLanguages = ["zh-Hans", "en-US"]
+        request.usesLanguageCorrection = true
+
+        try handler.perform([request])
+        guard let observations = request.results else {
+            throw OCRServiceError.recognitionFailed
+        }
+
+        return observations
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: "\n")
+    }
+}

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,7 @@
+# Proposed Follow-up Issues
+
+1. **Secrets Management UI** – Provide an in-app settings surface to capture and update GPT/Notion credentials and endpoints instead of relying on manual Keychain inserts.
+2. **LLM Response Validation** – Add JSON schema validation with graceful retry logic when the language model returns malformed or partial data.
+3. **Enhanced Notion Sync** – Support updating existing tasks by external ID and handle status transitions (e.g., auto-mark overdue tasks).
+4. **Shortcut Error Feedback** – Surface localized, user-friendly error messages back to Shortcuts when OCR, GPT, or Notion operations fail.
+5. **Unit Test Coverage** – Introduce mocks for the OCR, GPT, and Notion services to enable unit testing of the intent workflow.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# OcrToNotion
+# OcrToNotion App Intents
+
+一个示例性的 App Intents 扩展，演示如何在 iOS / iPadOS 上通过快捷指令完成以下自动化流程：
+
+1. 获取最近截图并进行 OCR 文本识别。
+2. 调用配置的 GPT 模型将截图内容解析为 JSON 格式的任务。
+3. 将任务同步创建到指定的 Notion 数据库中。
+
+## 目录结构
+
+```
+AppIntents/
+├── Models/
+│   └── TodoItem.swift           # LLM 输出 JSON 的数据模型
+├── Services/
+│   ├── GPTService.swift         # 封装 gpt-5-nano API 调用
+│   ├── JSONDecoder+yyyyMMdd.swift
+│   ├── NotionService.swift      # 将任务写入 Notion 的网络层
+│   └── OCRService.swift         # 基于 Vision 的 OCR
+└── ProcessScreenshotIntent.swift # 组合整个流程的 App Intent
+```
+
+## 快捷指令运行流程
+
+1. **触发方式**：将快捷指令绑定到轻点背面或 Action Button。
+2. **获取截图**：使用快捷指令内置动作「获取最近的屏幕快照」。
+3. **OCR**：将截图文件传给本项目提供的 `ProcessScreenshotIntent`。
+4. **LLM 解析**：App Intent 在后台调用 gpt-5-nano，输出合法 JSON。
+5. **Notion 写入**：根据 JSON 自动在 Notion 数据库中创建任务并返回任务链接。
+
+## App Intent 参数
+
+| 参数         | 类型        | 说明                                 |
+|--------------|-------------|--------------------------------------|
+| `screenshot` | `IntentFile`| 快捷指令传入的截图文件               |
+| `currentDate`| `Date`      | 便于 LLM 解析自然语言日期的参考日期 |
+
+App Intent 的返回值为一个 `URL` 数组，表示在 Notion 中创建的任务页面地址。
+
+## 依赖与框架
+
+* **Vision**：完成截图的文字识别。
+* **AppIntents**：定义快捷指令可调用的 Intent。
+* **Security**：从 Keychain 中读取敏感凭据。
+* **Foundation / URLSession**：访问远程 API。
+
+请确保在 `Info.plist` 中为 App Intents 扩展增加对网络访问的 `NSAppTransportSecurity` 配置（如果调用的 API 非 HTTPS，需要额外豁免）。
+
+## 密钥管理
+
+敏感信息不会硬编码在源码中。`Secrets` 结构体通过 `KeychainHelper` 从系统钥匙串读取下列键值：
+
+| Keychain Key               | 说明                                       |
+|---------------------------|--------------------------------------------|
+| `gpt_api_key`             | GPT 服务的 API Token                       |
+| `gpt_endpoint`            | GPT Chat Completions Endpoint（例如 `https://api.gpt.ge/v1/chat/completions`） |
+| `gpt_model`               | 调用的模型名称（例如 `gpt-5-nano`）        |
+| `notion_token`            | Notion 集成的 Access Token                 |
+| `notion_data_source_id`   | Notion 数据源 ID                           |
+| `notion_pages_endpoint`   | Notion 创建页面的 Endpoint（例如 `https://api.notion.com/v1/pages`） |
+| `notion_api_version`      | Notion API 版本号（例如 `2025-09-03`）     |
+
+建议在 App 内提供调试界面或使用配置描述文件，将用户提供的密钥与 Endpoint/版本信息写入 Keychain。
+
+## 错误处理
+
+* `OCRService` 在无法识别截图时会抛出 `OCRServiceError`。
+* `GPTService`/`NotionService` 对非 2xx HTTP 状态抛出 `invalidResponse`。
+* `Secrets` 在缺失凭据时抛出 `SecretsError.missingKey`，可在快捷指令中捕获并提示用户。
+
+## 与快捷指令集成
+
+1. 在 Xcode 中为 iOS 17+ 目标创建带 App Intents Extension 的项目，将上述源码放入扩展目标。
+2. 在 `AppIntents` 文件夹中注册 `ProcessScreenshotIntent`。编译后，快捷指令应用会自动发现新的 Intent。
+3. 在快捷指令中串联动作：
+   - 获取最近的屏幕快照
+   - 调用 `OCR 截图并同步到 Notion`（传入截图与当前日期）
+   - 对返回的链接进行后续处理（例如打开或通知）。
+
+## 可选优化
+
+* 为 LLM 请求添加重试策略或温度调节参数。
+* 将 `generateTodos` 改为流式解析，处理大段文本。
+* 在 Notion 返回失败时记录日志并提示用户。
+
+## 隐私提醒
+
+请勿将真实的 API Key 和 Token 保存在版本控制中。建议通过 CI 注入或在运行时由用户输入后写入 Keychain。


### PR DESCRIPTION
## Summary
- parameterize the GPT and Notion clients so API keys, endpoints, and models are supplied at runtime
- extend the Secrets helper to read all configuration values from the Keychain and validate URLs
- document the required Keychain entries and capture planned enhancements in ISSUES.md

## Testing
- not run (iOS-specific project skeleton)


------
https://chatgpt.com/codex/tasks/task_b_68d484ebf614832d8a18ed1467bfa9b0